### PR TITLE
Give the figwheel target a default server IP.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -52,7 +52,7 @@
 
   :figwheel {;; :http-server-root "public" ;; default and assumes "resources"
              ;; :server-port 5449
-             ;; :server-ip "127.0.0.1"
+             :server-ip "127.0.0.1"
 
              :css-dirs ["resources/public/css"]} ;; watch and update CSS
 


### PR DESCRIPTION
This change would be super cool for testing because the browser would not open with "0.0.0.0:<port>" which has to be change manually any time the REPL is connected.

Thanks!